### PR TITLE
Dropzone autoDiscover misfires in field template

### DIFF
--- a/src/resources/views/fields/dropzone_media.blade.php
+++ b/src/resources/views/fields/dropzone_media.blade.php
@@ -70,9 +70,8 @@
 
 @push('crud_fields_scripts')
 	<script type="text/javascript">
+		Dropzone.autoDiscover = false;
 		jQuery(document).ready(function() {
-			Dropzone.autoDiscover = false;
-
 			var dOptions = {
 				url: "{{ url($crud->route . '/' . $entry->id . '/media') }}",
 				previewTemplate: '{!! str_replace(array("\r\n", "\r", "\n"), "", addslashes(View::getSection("previewTemplate"))); !!}',


### PR DESCRIPTION
> By the time the document.ready function fires, all libraries have loaded (including Dropzone), meaning it will automatically begin its search per its default configuration. By running this before the document is ready, you are overwriting that particular default of the library. 

Therefor the autoDiscover should be outside of the document ready.